### PR TITLE
combats uploader race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.7.3] - 2024-05-13
+
+### Added
+- Added conditional wait to combat potential parallel file system race condition when pipeline components are all running synchronously.  Only waits when file that should exist doesn't exist.  
+
 ## [0.7.2] - 2024-05-03
 
 ### Fixed

--- a/uploader/uploader.py
+++ b/uploader/uploader.py
@@ -31,7 +31,12 @@ class Worker(threading.Thread):
             data = json.loads(self.body)
             file = os.path.join("/output", data['cdr_output'])
             logging.debug(f"Uploading data for {data['cog_id']} from {file}")
-            if not os.path.exists(file):
+            counter = 0
+            while not os.path.exists(file):
+                counter = counter + 1
+                if counter > 2: # maybe make a variable above
+                    raise ValueError(f"File {file} does not exist for uploader!!!")  
+                time.sleep(1)
                 time.sleep(.1)
                 if not os.path.exists(file):
                     time.sleep(1)

--- a/uploader/uploader.py
+++ b/uploader/uploader.py
@@ -36,7 +36,7 @@ class Worker(threading.Thread):
                 if not os.path.exists(file):
                     time.sleep(1)
                     if not os.path.exists(file):
-                        print(f"ERROR!  File {file} does not exist for uploader even after a wait!")
+                        logging.exception(f"ERROR!  File {file} does not exist for uploader even after a wait!")
                         raise ValueError(f"File {file} does not exist for uploader!!!")                        
             # only upload if less than certain size
             if os.path.getsize(file) > max_size * 1024 * 1024:  # size in bytes


### PR DESCRIPTION
Putting in a CONDITIONAL wait to combat a race condition in the distributed file system.  It first checks to see if the file exists. If it doesn't, it waits .1 seconds, if it still doesn't, it waits 1.0 seconds.  Then it raises high holy hell about the file not existing.  

So if it does indeed exist, we've only incurred the cost of running a single existence check and an if, so it will only do the wait if it already HAS hit the race condition.